### PR TITLE
Hardcoding the WEB3 PROVIDER LOCATION for now

### DIFF
--- a/src/javascript/web3/index.js
+++ b/src/javascript/web3/index.js
@@ -10,7 +10,7 @@ if (typeof web3 !== 'undefined') {
   _web3Instance = new Web3(web3.currentProvider);
 } else {
   // set the provider you want from Web3.providers
-  _web3Instance = new Web3(new Web3.providers.HttpProvider(WEB3_PROVIDER_LOCATION));
+  _web3Instance = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
 }
 
 _web3Instance.eth.getAccounts(function(err, accs) {


### PR DESCRIPTION
This gets rid of the need to install MetaMask or Mist to use the application
with ethereumjs-testrpc for now. It probably also prevents Mist or MetaMask
from working, but those are problems for later